### PR TITLE
feat(output): Calculating and showing width if -w is not given

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -206,7 +206,7 @@ func init() {
 	// flags to control look
 	rootCmd.Flags().BoolP("edit", "e", false, "edit content before the creating screenshot")
 	rootCmd.Flags().BoolP("show-cmd", "c", false, "include command in screenshot")
-	rootCmd.Flags().IntP("width", "w", 132, "width of screen in chars")
+	rootCmd.Flags().IntP("width", "w", 0, "width of screen in chars")
 
 	// flags for output related settings
 	rootCmd.Flags().StringP("filename", "f", "out.png", "filename of the screenshot")

--- a/internal/img/output.go
+++ b/internal/img/output.go
@@ -21,6 +21,7 @@
 package img
 
 import (
+	"fmt"
 	"image"
 	"image/color"
 	"image/png"
@@ -73,7 +74,7 @@ type Scaffold struct {
 var thisColNum int
 
 func NewImageCreator() Scaffold {
-	f := 2.0
+	f := 1.0
 
 	fontRegular, _ := truetype.Parse(fonts.JetBrainsMonoRegular)
 	fontBold, _ := truetype.Parse(fonts.JetBrainsMonoBold)
@@ -133,6 +134,8 @@ func (s *Scaffold) fontHeight() float64 {
 
 func (s *Scaffold) measureContent() (width float64, height float64) {
 	var tmp = make([]rune, len(s.content))
+	var tmpColNum int
+
 	for i, cr := range s.content {
 		tmp[i] = cr.Symbol
 	}
@@ -145,16 +148,25 @@ func (s *Scaffold) measureContent() (width float64, height float64) {
 		"\n",
 	)
 
-	// width, max width of all lines
 	tmpDrawer := &font.Drawer{Face: s.regular}
-	/* for _, line := range lines {
-		advance := tmpDrawer.MeasureString(line)
-		if lineWidth := float64(advance >> 6); lineWidth > width {
-			width = lineWidth
-		}
-	} */
+	if thisColNum < 1 {
 
-	width = float64(tmpDrawer.MeasureString(strings.Repeat("a", thisColNum)) >> 6) // TODO 132 chars
+		// width, max width of all lines
+
+		for _, line := range lines {
+			advance := tmpDrawer.MeasureString(line)
+			if lineWidth := float64(advance >> 6); lineWidth > width {
+				width = lineWidth
+				tmpColNum = bunt.PlainTextLength(line)
+			}
+		}
+		fmt.Printf("scale --width %d\n", tmpColNum)
+	} else {
+
+		// getting from flag
+
+		width = float64(tmpDrawer.MeasureString(strings.Repeat("a", thisColNum)) >> 6)
+	}
 
 	// height, lines times font height and line spacing
 	height = float64(len(lines)) * s.fontHeight() * s.lineSpacing


### PR DESCRIPTION
Reveals the maximum number of characters in input. Useful if you want to have same scale of diffrent shots. Run the widest one without -w, note the scale. Then run remaining ones with -w and scale given.